### PR TITLE
Basmallah should have a shaddah in 95 and 97

### DIFF
--- a/sql/03-basmallah-shaddah.sql
+++ b/sql/03-basmallah-shaddah.sql
@@ -1,0 +1,3 @@
+-- use the basmallah glyph with a shaddah on suras teen and qadr
+-- suras 95 and 97 on pages 597 and 598. see also #30.
+update glyph_page_line set glyph_id=4 where glyph_page_line_id in(87950,88094);


### PR DESCRIPTION
This patch replaces the basmallah glyph with the one that has a shaddah
for suras Tin and Qadr (pages 597 and 598). Fixes #30.