### PR TITLE
Edit Dockerfile from debian to buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:buster
 
 MAINTAINER Hossam Hammady <github@hammady.net>
 
@@ -34,6 +34,8 @@ RUN cd /app && \
     perl Makefile.PL && \
     make && \
     make install
+
+RUN find /app -type f -name '*.pl' -exec sed -i 's/\r$//' {} \;
 
 RUN sed -i 's/localhost/mysql/' /app/config/database.yaml
 


### PR DESCRIPTION
Made two moidifications to make it working, as discussed in the following issue : https://github.com/quran/quran.com-images/issues/49

1.  From Debian Jessie to Buster, because the binary-amd64 was not available inside the Jessie image, here it is for Buster : /debian-security/dists/buster/updates/main/binary-amd64 
2.  Removed the '\r' character which was causing this bug : /usr/bin/env: 'perl\r': No such file or directory (the '\r' was not removed from the perl files)

The image is now working fine al hamdouliLlah